### PR TITLE
sungmi/orsh_cancel

### DIFF
--- a/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SalesByItem/Contents.tsx
+++ b/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SalesByItem/Contents.tsx
@@ -170,7 +170,7 @@ const Contents = () => {
   return (
     <Box sx={{ height: 288, mb: 2 }}>
       <Stack direction="row" justifyContent="flex-end" sx={{ mt: 2, mb: 1 }}>
-        <Typography variant="body2">단위: 만 원</Typography>
+        <Typography variant="body2">단위: 천 원</Typography>
       </Stack>
       <Bar options={options} data={data} />
     </Box>

--- a/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SalesByItem2/Contents.tsx
+++ b/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SalesByItem2/Contents.tsx
@@ -169,7 +169,7 @@ const Contents = () => {
   return (
     <Box sx={{ height: 288, mb: 2 }}>
       <Stack direction="row" justifyContent="flex-end" sx={{ mt: 2, mb: 1 }}>
-        <Typography variant="body2">단위: 만 원</Typography>
+        <Typography variant="body2">단위: 천 원</Typography>
       </Stack>
       <Bar options={options} data={data} />
     </Box>

--- a/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SrvcSales/Legend.tsx
+++ b/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/SrvcSales/Legend.tsx
@@ -17,7 +17,7 @@ const Legend = (props: LegendProps) => {
   return (
     <Box>
       <Typography variant="body2" sx={{ textAlign: "right", pb: 5 }}>
-        단위: 만 원
+        단위: 천 원
       </Typography>
       <Grid container columnSpacing={5}>
         {salesLabels.map(

--- a/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/Total/TotalContents/index.tsx
+++ b/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/components/Total/TotalContents/index.tsx
@@ -53,7 +53,7 @@ const Index = () => {
         </Grid>
         <Grid item xs={12}>
           <Stack direction="row" justifyContent="flex-end">
-            <Typography variant="body2">단위: 만 원</Typography>
+            <Typography variant="body2">단위: 천 원</Typography>
           </Stack>
           <Stack sx={{ height: 340 }}>
             <Charts

--- a/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/recoil/dashboardAtom.ts
+++ b/apps/bsadmin/src/app/(pages)/(dashboard)/dashboard/recoil/dashboardAtom.ts
@@ -1,4 +1,5 @@
 import { atom } from "recoil";
+import dayjs from "dayjs";
 
 // 유틸리티 함수
 const getCurrentDateInfo = () => {
@@ -16,12 +17,12 @@ const { year, month, quarter, half } = getCurrentDateInfo();
 // 대시보드 상태 정의
 export const startYearAtom = atom({
   key: "startYearAtom",
-  default: 2023,
+  default: dayjs().year(),
 });
 
 export const endYearAtom = atom({
   key: "endYearAtom",
-  default: 2023,
+  default: dayjs().year(),
 });
 
 export const dashboardYearAtom = atom({

--- a/apps/bsadmin/src/app/(pages)/(ledger)/(anlsltst)/(analysis)/ledger-analysis-report-list/[...slug]/AnalysisInfo.tsx
+++ b/apps/bsadmin/src/app/(pages)/(ledger)/(anlsltst)/(analysis)/ledger-analysis-report-list/[...slug]/AnalysisInfo.tsx
@@ -843,18 +843,18 @@ const AnalysisInfo = () => {
                 <Link href="/ledger-analysis-report-list">
                   <OutlinedButton size="small" buttonName="목록" />
                 </Link>
-                <ContainedButton
-                  size="small"
-                  buttonName="수정" // 수정 가능 페이지로 이동
-                  onClick={goModifyPage}
-                />
-                {/*{isEdit === "Y" && (*/}
-                {/*  <ContainedButton*/}
-                {/*    size="small"*/}
-                {/*    buttonName="수정"*/}
-                {/*    onClick={goModifyPage}*/}
-                {/*  />*/}
-                {/*)}*/}
+                {/*<ContainedButton*/}
+                {/*  size="small"*/}
+                {/*  buttonName="수정" // 수정 가능 페이지로 이동*/}
+                {/*  onClick={goModifyPage}*/}
+                {/*/>*/}
+                {isEdit === "Y" && (
+                  <ContainedButton
+                    size="small"
+                    buttonName="수정"
+                    onClick={goModifyPage}
+                  />
+                )}
               </Stack>
             </Box>
           </>

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
@@ -48,7 +48,7 @@ import OrderRegChckNgsAnalysis from "./components/OrderRegChckNgsAnalysis";
 import dynamic from "next/dynamic";
 import useCalculatedHeight from "../../../hooks/useCalculatedHeight";
 import {useSession} from "next-auth/react";
-import DeleteBtn from "./components/DeleteBtn";
+import CancelBtn from "./components/CancelBtn";
 
 const LazyOrderRegChckNgsAnalysis = dynamic(
   () => import("./components/OrderRegChckNgsAnalysis"),
@@ -263,7 +263,7 @@ export default function ListOrshbs() {
                         />
 
                         {/* userId와 createdBy가 일치할 때 취소 버튼 표시 */}
-                        {userId === row.createdBy && <DeleteBtn orshUkey={row.orshUkey}/>}
+                        {userId === row.createdBy && <CancelBtn orshUkey={row.orshUkey}/>}
 
                         {/* isMastered가 'Y'일 때 LazyOrderRegChckNgsAnalysis 실행 */}
                         {row.isMastered === "Y" && (

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, {useCallback, useMemo} from "react";
 import {
-  DataCountResultInfo,
-  DataTableBase,
-  DataTableFilter,
-  Title1,
-  LeaderCip,
-  ContainedButton,
-  SelectBox,
-  Form,
-  OutlinedButton,
-  cjbsTheme,
-  FileDownloadBtn,
-  FullHeightLoading,
+    DataCountResultInfo,
+    DataTableBase,
+    DataTableFilter,
+    Title1,
+    LeaderCip,
+    ContainedButton,
+    SelectBox,
+    Form,
+    OutlinedButton,
+    cjbsTheme,
+    FileDownloadBtn,
+    FullHeightLoading, AlertModal,
 } from "cjbsDSTM";
 import {
   Stack,
@@ -41,12 +41,14 @@ import { toast } from "react-toastify";
 import ServiceSelectModal from "./ServiceSelectModal";
 import KeywordSearch from "../../../components/KeywordSearch";
 import { usePathname, useSearchParams } from "next/navigation";
-import { fetcher } from "api";
+import {DELETE, fetcher} from "api";
 import { styled } from "@mui/material/styles";
 import NoDataView from "../../../components/NoDataView";
 import OrderRegChckNgsAnalysis from "./components/OrderRegChckNgsAnalysis";
 import dynamic from "next/dynamic";
 import useCalculatedHeight from "../../../hooks/useCalculatedHeight";
+import {useSession} from "next-auth/react";
+import DeleteBtn from "./components/DeleteBtn";
 
 const LazyOrderRegChckNgsAnalysis = dynamic(
   () => import("./components/OrderRegChckNgsAnalysis"),
@@ -72,11 +74,12 @@ const LightTooltip = styled(({ className, ...props }: TooltipProps) => (
 export default function ListOrshbs() {
   //const tableRef = React.useRef<any>(null);
   const table = useRef(null);
+  const { data: session, status } = useSession();
+  const userId = session?.uid;
 
   const [page, setPage] = useState<number>(1);
   const [size, setSize] = useState<number>(100);
   const [filters, setFilters] = useState("");
-
   const { mutate } = useSWRConfig();
 
   // ListAPI Call
@@ -232,42 +235,52 @@ export default function ListOrshbs() {
       },
       {
         name: "주문상태",
-        cell: (row: { isOrderStatus: string; isMastered: string }) => {
-          return row.isOrderStatus == "N" ? (
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Typography
-                variant="subtitle2"
-                color={cjbsTheme.palette.info.main}
-              >
-                주문대기
-              </Typography>
-              <Divider orientation="vertical" variant="middle" flexItem />
-              <OutlinedButton
-                buttonName="수정"
-                size="small"
-                onClick={() => goDetailPage(row)}
-              />
+        cell: (row: { isOrderStatus: string; isMastered: string; isCancel: string; createdBy: number; orshUkey: string}) => {
+            // isCancel이 'Y'인 경우 '주문취소' 표시
+            if (row.isCancel === "Y") {
+                return (
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                        <Typography variant="subtitle2">
+                            주문취소
+                        </Typography>
+                    </Stack>
+                );
+            }
+            // isOrderStatus가 'N'이고 isCancel이 'N'인 경우 '주문대기'와 버튼들 표시
+            if (row.isOrderStatus === "N" && row.isCancel === "N") {
+                return (
+                    <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="subtitle2" color={cjbsTheme.palette.info.main}>
+                            주문대기
+                        </Typography>
+                        <Divider orientation="vertical" variant="middle" flexItem />
 
-              {row.isMastered == "Y" ? (
-                <>
-                  {/*<Divider orientation="vertical" variant="middle" flexItem />*/}
-                  {/*<ContainedButton*/}
-                  {/*  buttonName="+오더등록"*/}
-                  {/*  size="small"*/}
-                  {/*  onClick={() => goLinkOrderPage(row)}*/}
-                  {/*/>*/}
-                  <LazyOrderRegChckNgsAnalysis row={row} />
-                </>
-              ) : (
-                ""
-              )}
-            </Stack>
-          ) : (
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              {/*<Box data-tag="allowRowEvents">주문완료</Box>*/}
-              <Typography variant="subtitle2">주문완료</Typography>
-            </Stack>
-          );
+                        {/* 수정 버튼 */}
+                        <OutlinedButton
+                            buttonName="수정"
+                            size="small"
+                            onClick={() => goDetailPage(row)}
+                        />
+
+                        {/* userId와 createdBy가 일치할 때 취소 버튼 표시 */}
+                        {userId === row.createdBy && <DeleteBtn orshUkey={row.orshUkey}/>}
+
+                        {/* isMastered가 'Y'일 때 LazyOrderRegChckNgsAnalysis 실행 */}
+                        {row.isMastered === "Y" && (
+                            <LazyOrderRegChckNgsAnalysis row={row} />
+                        )}
+                    </Stack>
+                );
+            }
+
+            // isOrderStatus가 'Y'인 경우 '주문완료' 표시
+            if (row.isOrderStatus === "Y") {
+                return (
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                        <Typography variant="subtitle2">주문완료</Typography>
+                    </Stack>
+                );
+            }
         },
         width: "260px",
       },

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
@@ -80,7 +80,6 @@ export default function ListOrshbs() {
   const [page, setPage] = useState<number>(1);
   const [size, setSize] = useState<number>(100);
   const [filters, setFilters] = useState("");
-  const { mutate } = useSWRConfig();
 
   // ListAPI Call
   // const { data } = useFiltersList("orsh/bs/intn", filters);
@@ -98,12 +97,11 @@ export default function ListOrshbs() {
   for (const [key, value] of searchParams.entries()) {
     resultObject[key] = value;
   }
-  console.log(">>>>>>>>>", resultObject);
 
   const result = "?" + new URLSearchParams(resultObject).toString();
-  console.log("RESULT@#@#@#", JSON.stringify(result));
+  // console.log("RESULT@#@#@#", JSON.stringify(result));
 
-  const { data } = useSWR(
+  const { data, mutate } = useSWR(
     JSON.stringify(resultObject) !== "{}"
       ? `/orsh/bs/intn/list${result}&page=${page}&size=${size}`
       : `/orsh/bs/intn/list?page=${page}&size=${size}`,
@@ -112,11 +110,11 @@ export default function ListOrshbs() {
       suspense: true,
     },
   );
-  console.log("고객주문서 LIST DATA", data);
+  // console.log("고객주문서 LIST DATA", data);
 
-  console.log("data >>>>>>> : ", data);
+  // console.log("data >>>>>>> : ", data);
   const totalElements = data.pageInfo.totalElements;
-  console.log("totalElements >>>>>>> : ", totalElements);
+  // console.log("totalElements >>>>>>> : ", totalElements);
   // const handleRowSelected = (rows: any) => {
   //   setSelectedOption(rows.selectedRows);
   //   setSelectedRowCnt(rows.selectedCount);
@@ -263,7 +261,8 @@ export default function ListOrshbs() {
                         />
 
                         {/* userId와 createdBy가 일치할 때 취소 버튼 표시 */}
-                        {userId === row.createdBy && <CancelBtn orshUkey={row.orshUkey}/>}
+                        {userId === row.createdBy &&
+                            <CancelBtn mutate={mutate} orshUkey={row.orshUkey}/>}
 
                         {/* isMastered가 'Y'일 때 LazyOrderRegChckNgsAnalysis 실행 */}
                         {row.isMastered === "Y" && (

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/ListOrshbs.tsx
@@ -300,10 +300,12 @@ export default function ListOrshbs() {
     srvcTypeAbb: string;
     isOrderStatus: string;
     anlsTypeAbb: string;
+    isCancel: string;
   }) => {
     const orshUkey = row.orshUkey;
     const srvcTypeAbb = row.srvcTypeAbb;
-    const isOrderStatus = row.isOrderStatus;
+    // const isOrderStatus = row.isOrderStatus;
+    const isOrderStatus = row.isCancel === "Y" ? "Y" : row.isOrderStatus;
     const anlsTypeAbb = row.anlsTypeAbb;
     router.push(
       "/orshbs-list/" +

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/CancelBtn.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/CancelBtn.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from "react";
 import { DELETE } from "api";
 import { useRouter } from "next-nprogress-bar";
-import { AlertModal, ContainedButton } from "cjbsDSTM";
+import {AlertModal, ContainedButton, DeletedButton} from "cjbsDSTM";
 import { useParams } from "next/navigation";
 import {mutate} from "swr";
 import {toast} from "react-toastify";
 
-const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
+const CancelBtn = ({orshUkey} : { orshUkey:string; }) => {
   console.log("orshUkey : {}", orshUkey);
   const params = useParams();
   const router = useRouter();
@@ -19,13 +19,13 @@ const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
       if (res.success) {
         mutate(`/orshbs-list/`);
         toast("취소 되었습니다.");
-        handleAlertClose();
       } else {
         setSubAlertMsg(res.message);
       }
     } catch (error) {
       console.error("Error submitting form", error);
     } finally {
+      handleAlertClose();
     }
   };
 
@@ -40,9 +40,8 @@ const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
 
   return (
     <>
-      <ContainedButton
+      <DeletedButton
           buttonName="취소"
-          color="error"
           onClick={handleAlertOpen}
           size="small"
       />
@@ -58,4 +57,4 @@ const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
   );
 };
 
-export default DeleteBtn;
+export default CancelBtn;

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/CancelBtn.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/CancelBtn.tsx
@@ -3,21 +3,21 @@ import { DELETE } from "api";
 import { useRouter } from "next-nprogress-bar";
 import {AlertModal, ContainedButton, DeletedButton} from "cjbsDSTM";
 import { useParams } from "next/navigation";
-import {mutate} from "swr";
 import {toast} from "react-toastify";
+import {mutate, useSWRConfig} from "swr";
+import {CanceledError} from "axios";
 
-const CancelBtn = ({orshUkey} : { orshUkey:string; }) => {
-  console.log("orshUkey : {}", orshUkey);
+const CancelBtn = ({orshUkey, mutate} : { orshUkey:string; mutate:any}) => {
   const params = useParams();
   const router = useRouter();
   const [alertModalOpen, setAlertModalOpen] = useState<boolean>(false);
   const [subAlertMsg, setSubAlertMsg] = useState("");
-  const handleOrshDelete = async (orshUkey: string) => {
+  const handleOrshCancel = async (orshUkey: string) => {
     try {
       const res = await DELETE(`/orsh/bs/${orshUkey}`);
       console.log("Response", res);
       if (res.success) {
-        mutate(`/orshbs-list/`);
+        mutate();
         toast("취소 되었습니다.");
       } else {
         setSubAlertMsg(res.message);
@@ -47,7 +47,7 @@ const CancelBtn = ({orshUkey} : { orshUkey:string; }) => {
       />
       <AlertModal
           onClose={handleAlertClose}
-          alertMainFunc={() => handleOrshDelete(orshUkey)}
+          alertMainFunc={() => handleOrshCancel(orshUkey)}
           open={alertModalOpen}
           mainMessage="취소를 진행하시겠습니까?"
           subMessage={subAlertMsg}

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/DeleteBtn.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/DeleteBtn.tsx
@@ -18,7 +18,7 @@ const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
       console.log("Response", res);
       if (res.success) {
         mutate(`/orshbs-list/`);
-        toast("삭제 되었습니다.");
+        toast("취소 되었습니다.");
         handleAlertClose();
       } else {
         setSubAlertMsg(res.message);

--- a/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/DeleteBtn.tsx
+++ b/apps/bsadmin/src/app/(pages)/(orshbs)/orshbs-list/components/DeleteBtn.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useState } from "react";
+import { DELETE } from "api";
+import { useRouter } from "next-nprogress-bar";
+import { AlertModal, ContainedButton } from "cjbsDSTM";
+import { useParams } from "next/navigation";
+import {mutate} from "swr";
+import {toast} from "react-toastify";
+
+const DeleteBtn = ( {orshUkey} : { orshUkey:string; }) => {
+  console.log("orshUkey : {}", orshUkey);
+  const params = useParams();
+  const router = useRouter();
+  const [alertModalOpen, setAlertModalOpen] = useState<boolean>(false);
+  const [subAlertMsg, setSubAlertMsg] = useState("");
+  const handleOrshDelete = async (orshUkey: string) => {
+    try {
+      const res = await DELETE(`/orsh/bs/${orshUkey}`);
+      console.log("Response", res);
+      if (res.success) {
+        mutate(`/orshbs-list/`);
+        toast("삭제 되었습니다.");
+        handleAlertClose();
+      } else {
+        setSubAlertMsg(res.message);
+      }
+    } catch (error) {
+      console.error("Error submitting form", error);
+    } finally {
+    }
+  };
+
+  const handleAlertOpen = useCallback(() => {
+    setAlertModalOpen(true);
+  }, []);
+
+  const handleAlertClose = () => {
+    setAlertModalOpen(false);
+    setSubAlertMsg("");
+  };
+
+  return (
+    <>
+      <ContainedButton
+          buttonName="취소"
+          color="error"
+          onClick={handleAlertOpen}
+          size="small"
+      />
+      <AlertModal
+          onClose={handleAlertClose}
+          alertMainFunc={() => handleOrshDelete(orshUkey)}
+          open={alertModalOpen}
+          mainMessage="취소를 진행하시겠습니까?"
+          subMessage={subAlertMsg}
+          alertBtnName="취소"
+      />
+    </>
+  );
+};
+
+export default DeleteBtn;

--- a/apps/bsadmin/src/app/components/DynamicSumTableAnalysis/index.tsx
+++ b/apps/bsadmin/src/app/components/DynamicSumTableAnalysis/index.tsx
@@ -148,7 +148,7 @@ const Index = () => {
               <SingleDatePicker
                 inputName="anlsDttm"
                 required={true}
-                // includeDateIntervals={standDate()}
+                includeDateIntervals={standDate()}
               />
             </TD>
             <TH sx={{ width: "15%" }}>총 수량</TH>


### PR DESCRIPTION
## Tilte
내부 주문서 취소 기능 추가

## Description
내부 주문서 취소 기능 추가(임상개발팀, NGS 분석팀 요구사항)
작성자인 경우에만 내부 주문서 취소 가능

## Context
내부 주문서 이용자(임상팀, discovery, NGS 분석팀)들이 공통적으로 요청주신 사항. 작성자인 경우 주문 대기 상태(오더로 등록되기 전)에는 취소가 가능하도록 추가 요청
주문서 작성자인 경우 취소 기능 사용 가능.


## How To Test
주문서 > 내부 주문서 > 주문서 등록 후, 리스트에서 "취소" 버튼 클릭으로 테스트 가능

## Additional Comments
기타 FIX 사항 
1. 대시보드 default year 2023년으로 지정되어있음 > 현재년도 호출로 변경
2. 대시보드 단위 만원 > 천원으로 변경